### PR TITLE
Adapt bridge to work with rclpy1.9.1 to solve error of use_sim_time; …

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -389,7 +389,7 @@ def main(args=None):
 
     parameters['host'] = carla_bridge.get_param('host', 'localhost')
     parameters['port'] = carla_bridge.get_param('port', 2000)
-    parameters['timeout'] = carla_bridge.get_param('timeout', 2)
+    parameters['timeout'] = carla_bridge.get_param('timeout', 10)
     parameters['passive'] = carla_bridge.get_param('passive', False)
     parameters['synchronous_mode'] = carla_bridge.get_param('synchronous_mode', True)
     parameters['synchronous_mode_wait_for_vehicle_control_command'] = carla_bridge.get_param(

--- a/ros_compatibility/src/ros_compatibility/node.py
+++ b/ros_compatibility/src/ros_compatibility/node.py
@@ -138,7 +138,7 @@ elif ROS_VERSION == 2:
             super(CompatibleNode, self).__init__(
                 name,
                 allow_undeclared_parameters=True,
-                automatically_declare_parameters_from_overrides=True,
+                automatically_declare_parameters_from_overrides=False,
                 parameter_overrides=[param],
                 **kwargs)
 


### PR DESCRIPTION
…set automatically_declare_parameters_from_overrides=False and increase timeout when starting bridge